### PR TITLE
added claim tax benefits service and a missing gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/en/index.html
+++ b/en/index.html
@@ -111,6 +111,12 @@
               <td class="left-mobile" data-label="Lead department or team"><div class="clearfix"></div>Canadian Digital Service</td>
               <td class="left-mobile" data-label="Feedback email address"><div class="clearfix"></div><a href="mailto:cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a></td>
             </tr>
+
+            <tr valign="top" class="d2">
+              <td data-label="Service name" class="left-mobile"><div class="clearfix"></div>Claim Tax Benefits - <a href="https://claim-tax-benefits.alpha.canada.ca">claim-tax-benefits.alpha.canada.ca</a></td>
+              <td class="left-mobile" data-label="Lead department or team"><div class="clearfix"></div>Canadian Digital Service & Canada Revenue Agency</td>
+              <td class="left-mobile" data-label="Feedback email address"><div class="clearfix"></div><a href="mailto:cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a></td>
+            </tr>
           </tbody>
 </table>
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -111,6 +111,12 @@
               <td class="left-mobile" data-label="Équipe ou ministère responsable"><div class="clearfix"></div>Service numérique canadien</td>
               <td class="left-mobile" data-label="Adresse de courriel pour la rétroaction"><div class="clearfix"></div><a href="mailto:cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a></td>
             </tr>
+
+            <tr valign="top" class="d2">
+              <td data-label="Désignation du service" class="left-mobile"><div class="clearfix"></div>Réclamer des avantages fiscaux - <a href="https://reclamer-des-avantages-fiscaux.alpha.canada.ca/">reclamer-des-avantages-fiscaux.alpha.canada.ca</a></td>
+              <td class="left-mobile" data-label="Équipe ou ministère responsable"><div class="clearfix"></div>Service numérique canadien & Agence du revenu du Canada</td>
+              <td class="left-mobile" data-label="Adresse de courriel pour la rétroaction"><div class="clearfix"></div><a href="mailto:cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a></td>
+            </tr>
           </tbody>
 </table>
 


### PR DESCRIPTION
This PR consist in adding information about the Claim Tax Benefits service to the english and french static pages. I also added a missing `gitignore` file to initially exclude `.DS_Store`.