### PR TITLE
Covid Alert - download + app association 

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,0 +1,13 @@
+{
+   "applinks": {
+      "apps": [],
+      "details": [
+         {
+            "appID": "J7J9Q6KTWJ.ca.gc.hcsc.canada.covidalert.dev",
+            "paths": [
+               "*"
+            ]
+         }
+      ]
+   }
+}

--- a/covid-alert.html
+++ b/covid-alert.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Covid Alert</title>
+  </head>
+  <body>
+    <script>
+      function redirect() {
+        window.location = "https://canada.ca/covid-alert";
+      }
+      redirect();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
We're looking to support Universal links in the Covid Alert app.

In order to do so we need to host an `apple-app-site-association` json file to verify the domain / app connection.

Why alpha.canada.ca?

Currently we've tested this feature on our servers but are looking to use a short +  recognizable domain + url.

This PR also includes a "download" page which I've placed in the root to keep the as short as possible url.

We will be using this URL for QR code scanning  (I can provide more details as needed)


https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html#//apple_ref/doc/uid/TP40016308-CH12-SW1 