### PR TITLE
Updated apple-app-site-association

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -4,11 +4,11 @@
     "details": [
       {
         "appID": "J7J9Q6KTWJ.ca.gc.hcsc.canada.covidalert.dev",
-        "paths": ["*"]
+        "paths": ["/covid-alert.html"]
       },
       {
         "appID": "J7J9Q6KTWJ.ca.gc.hcsc.canada.stopcovid",
-        "paths": ["*"]
+        "paths": ["/covid-alert.html"]
       }
     ]
   }


### PR DESCRIPTION
Fixing issue where browsing to alpha.canada.ca would open the Covid Alert iOS application (if installed)